### PR TITLE
[update] awsid を v0.2.1 に更新

### DIFF
--- a/awsid.rb
+++ b/awsid.rb
@@ -1,21 +1,21 @@
 class Awsid < Formula
   desc "AWSアカウントのエイリアス名からアカウントIDを出力するCLIツール"
   homepage "https://github.com/juliar13/awsid"
-  version "0.2.0"
+  version "0.2.1"
 
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/juliar13/awsid/raw/main/dist/awsid_darwin_arm64.tar.gz"
-      sha256 "eae57e2f24b850ba5a48fe1e25bba6c07ec5e6d7f19e4355441691eabfb32539"
+      sha256 "8b1fa29ff2d10ad94ff27206a3c0501e46eb01e9806b1a96d0e2362e2cad1f2d"
     else
       url "https://github.com/juliar13/awsid/raw/main/dist/awsid_darwin_amd64.tar.gz"
-      sha256 "d400f765a3d95a5ba8f21fd2f16ea00a1725e25be7e6039fb738f02b23c026e9"
+      sha256 "c9aecb344c196de78e56468f3ce550f4bed905aa989adaa98183ef0c4aab562c"
     end
   end
 
   on_linux do
     url "https://github.com/juliar13/awsid/raw/main/dist/awsid_linux_amd64.tar.gz"
-    sha256 "def4b2e541b95b0a290f0fe931e1a51dafaf23ab10c29d5ebfa859b9408bf0e9"
+    sha256 "8c3c318a29d817684cfc9ca59849cdc9ec092b3bf22158bf6d12fd1af0239745"
   end
 
   def install


### PR DESCRIPTION
## 概要

awsid Homebrew Formula を v0.2.1 に更新しました。

## 背景

awsid の新しいバージョン v0.2.1 がリリースされ、バージョン確認コマンド機能が追加されたため。

## 内容詳細

- バージョンを 0.2.0 から 0.2.1 に更新
- 全プラットフォーム（darwin arm64/amd64, linux amd64）のSHA256ハッシュを更新
- 新機能：--version フラグによるバージョン確認コマンド

## レビューポイント

- SHA256ハッシュが正しく更新されているか
- バージョン番号が適切に更新されているか

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated to Awsid version 0.2.1 with new download links and checksums for all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->